### PR TITLE
Add full animation mode support to ITE 829x (0x048d:0x8910)

### DIFF
--- a/src/ite_829x/ite_829x.c
+++ b/src/ite_829x/ite_829x.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0+
 /*!
  * Copyright (c) 2019-2023 TUXEDO Computers GmbH <tux@tuxedocomputers.com>
+ * Copyright (c) 2026 Valentin Lobstein <valentin@chocapikk.com>
  *
  * This file is part of tuxedo-drivers.
  *
@@ -16,6 +17,10 @@
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ * ITE 8910 protocol reverse-engineered from the Uniwill Control Center
+ * (perkey_api.dll + LedKeyboardSetting.exe .NET IL).
+ * Protocol documentation: https://chocapikk.com/posts/2026/reverse-engineering-ite8910-keyboard-rgb/
  */
 
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
@@ -34,213 +39,551 @@
 #include <linux/dmi.h>
 #include <linux/led-class-multicolor.h>
 
-MODULE_DESCRIPTION("TUXEDO Computers, ITE backlight driver");
+MODULE_DESCRIPTION("TUXEDO Computers, ITE 829x backlight driver with animation modes");
 MODULE_AUTHOR("TUXEDO Computers GmbH <tux@tuxedocomputers.com>");
+MODULE_AUTHOR("Valentin Lobstein <valentin@chocapikk.com>");
 MODULE_LICENSE("GPL");
 
-#define KEYBOARD_ROWS       6
-#define KEYBOARD_COLUMNS    20
+/* --- Hardware constants --- */
 
-#define get_led_id(row, col)    (u8)( ((row & 0x07) << 5) | (col & 0x1f) )
+#define KEYBOARD_ROWS		6
+#define KEYBOARD_COLUMNS	20
 
-#define HID_DATA_SIZE 6
+#define HID_DATA_SIZE		6
+#define REPORT_ID		0xcc
 
-// Keyboard events
+#define BRIGHTNESS_MAX		0x0a
+#define BRIGHTNESS_DEFAULT	0x00
+#define SPEED_MAX		0x0a
+#define SPEED_DEFAULT		0x00
+
+#define COLOR_CUSTOM		0xaa
+#define COLOR_SLOT_BASE		0xa1
+#define PRESET_SLOT_BASE	0x71
+
+#define get_led_id(row, col)	((u8)(((row) & 0x07) << 5 | ((col) & 0x1f)))
+
+/* --- HID command bytes --- */
+
+#define CMD_ANIMATION		0x00
+#define CMD_SET_LED		0x01
+#define CMD_BRIGHTNESS_SPEED	0x09
+#define CMD_BREATHING		0x0a
+#define CMD_FLASHING		0x0b
+#define CMD_WAVE_COLOR		0x15
+#define CMD_SNAKE_COLOR		0x16
+#define CMD_SCAN_COLOR		0x17
+#define CMD_RANDOM_COLOR	0x18
+
+/* --- Animation mode IDs (for CMD_ANIMATION) --- */
+
+#define ANIM_SPECTRUM_CYCLE	0x02
+#define ANIM_RAINBOW_WAVE	0x04
+#define ANIM_RANDOM		0x09
+#define ANIM_SCAN		0x0a
+#define ANIM_SNAKE		0x0b
+#define ANIM_CLEAR		0x0c
+
+/* --- Effect indices (sysfs) --- */
+
+enum ite829x_effect {
+	EFFECT_OFF = 0,
+	EFFECT_DIRECT,
+	EFFECT_SPECTRUM_CYCLE,
+	EFFECT_RAINBOW_WAVE,
+	EFFECT_BREATHING,
+	EFFECT_BREATHING_COLOR,
+	EFFECT_FLASHING,
+	EFFECT_FLASHING_COLOR,
+	EFFECT_RANDOM,
+	EFFECT_RANDOM_COLOR,
+	EFFECT_SCAN,
+	EFFECT_SNAKE,
+	EFFECT_WAVE,
+	EFFECT_COUNT,
+};
+
+static const char * const effect_names[] = {
+	[EFFECT_OFF]             = "off",
+	[EFFECT_DIRECT]          = "direct",
+	[EFFECT_SPECTRUM_CYCLE]  = "spectrum_cycle",
+	[EFFECT_RAINBOW_WAVE]    = "rainbow_wave",
+	[EFFECT_BREATHING]       = "breathing",
+	[EFFECT_BREATHING_COLOR] = "breathing_color",
+	[EFFECT_FLASHING]        = "flashing",
+	[EFFECT_FLASHING_COLOR]  = "flashing_color",
+	[EFFECT_RANDOM]          = "random",
+	[EFFECT_RANDOM_COLOR]    = "random_color",
+	[EFFECT_SCAN]            = "scan",
+	[EFFECT_SNAKE]           = "snake",
+	[EFFECT_WAVE]            = "wave",
+};
+
+/* Wave: 8 directions (preset 0x71-0x78, custom 0xA1-0xA8) */
+static const char * const wave_direction_names[] = {
+	"up_left", "up_right", "down_left", "down_right",
+	"up", "down", "left", "right",
+};
+#define WAVE_DIR_COUNT	ARRAY_SIZE(wave_direction_names)
+
+/* Snake: 4 diagonal directions (preset 0x71-0x74, custom 0xA1-0xA4) */
+static const char * const snake_direction_names[] = {
+	"up_left", "up_right", "down_left", "down_right",
+};
+#define SNAKE_DIR_COUNT	ARRAY_SIZE(snake_direction_names)
+
+/* --- Keyboard events --- */
+
 #define INT_KEY_B_NEXT		KEY_LIGHTS_TOGGLE
 
-static struct hid_device *kbdev = NULL;
+/* --- Driver state --- */
+
+static struct hid_device *kbdev;
 static struct mutex dev_lock;
 static struct mutex input_lock;
 
-// Brightness (0-10)
-#define ITE829X_KBD_BRIGHTNESS_MAX	0x0a
-#define ITE829X_KBD_BRIGHTNESS_DEFAULT	0x00
-// Default mode (index to mode_to_color array) or extra modes
-#define DEFAULT_MODE        6
-
-static struct ite8291_data {
+static struct ite829x_state {
 	int brightness;
-	int mode;
-} ti_data = {
-	.brightness = ITE829X_KBD_BRIGHTNESS_DEFAULT,
-	.mode = DEFAULT_MODE
+	int speed;
+	int effect;
+	int direction;		/* index into direction table */
+	u8 color1_r, color1_g, color1_b;
+	u8 color2_r, color2_g, color2_b;
+} state = {
+	.brightness = BRIGHTNESS_DEFAULT,
+	.speed = SPEED_DEFAULT,
+	.effect = EFFECT_DIRECT,
+	.direction = 0,
+	.color1_r = 0xff, .color1_g = 0x00, .color1_b = 0x00,
+	.color2_r = 0x00, .color2_g = 0x00, .color2_b = 0xff,
 };
 
 static struct led_classdev_mc clevo_mcled_cdevs[KEYBOARD_ROWS][KEYBOARD_COLUMNS];
 static struct mc_subled clevo_mcled_cdevs_subleds[KEYBOARD_ROWS][KEYBOARD_COLUMNS][3];
 
-// Color mode definition
-static int mode_to_color[] = { 0xff0000, 0x00ff00, 0x0000ff, 0xffff00, 0xff00ff, 0x00ffff, 0xffffff };
-// Length of color mode array
-static const int MODE_MAP_LENGTH = sizeof(mode_to_color)/sizeof(mode_to_color[0]);
-// Amount of extra modes in addition to the color ones
-static const int MODE_EXTRAS_LENGTH = 2;
+/* --- Low-level HID --- */
+
+/*
+ * Persistent DMA-safe buffer for HID reports. Allocated once at probe,
+ * reused for every send under dev_lock. Avoids per-call kzalloc/kfree
+ * overhead (critical during send_clear which sends 121 reports).
+ */
+static u8 *hid_buf;
 
 static int keyb_send_data(struct hid_device *dev, u8 cmd, u8 d0, u8 d1, u8 d2, u8 d3)
 {
-	int result = 0;
-	u8 *buf;
+	int result;
 
-	pr_debug("keyb_send_data: cmd: %hhu, d0: %hhu, d1: %hhu, d2: %hhu, d3: %hhu\n", cmd, d0, d1, d2, d3);
-
-	if (dev == NULL) {
+	if (!dev)
 		return -ENODEV;
-	}
 
 	mutex_lock(&dev_lock);
 
-	buf = kzalloc(HID_DATA_SIZE, GFP_KERNEL);
-	buf[0] = 0xcc;
-	buf[1] = cmd;
-	buf[2] = d0;
-	buf[3] = d1;
-	buf[4] = d2;
-	buf[5] = d3;
+	hid_buf[0] = REPORT_ID;
+	hid_buf[1] = cmd;
+	hid_buf[2] = d0;
+	hid_buf[3] = d1;
+	hid_buf[4] = d2;
+	hid_buf[5] = d3;
 
-	result = hid_hw_raw_request(dev, buf[0], buf, HID_DATA_SIZE, HID_FEATURE_REPORT, HID_REQ_SET_REPORT);
-	kfree(buf);
-
+	result = hid_hw_raw_request(dev, hid_buf[0], hid_buf, HID_DATA_SIZE,
+				    HID_FEATURE_REPORT, HID_REQ_SET_REPORT);
 	mutex_unlock(&dev_lock);
 
 	return result;
 }
 
-static void keyb_set_all(struct hid_device *dev, u8 color_red, u8 color_green, u8 color_blue)
-{
-	int row, col;
-	for (row = 0; row < KEYBOARD_ROWS; ++row) {
-		for (col = 0; col < KEYBOARD_COLUMNS; ++col) {
-			clevo_mcled_cdevs[row][col].subled_info[0].intensity = color_red;
-			clevo_mcled_cdevs[row][col].subled_info[1].intensity = color_green;
-			clevo_mcled_cdevs[row][col].subled_info[2].intensity = color_blue;
-			keyb_send_data(dev, 0x01, get_led_id(row, col), color_red, color_green, color_blue);
-		}
-	}
-}
+/* --- Command helpers --- */
 
-static void send_mode(struct hid_device *dev, int mode)
+static int last_sent_brightness = -1;
+static int last_sent_speed = -1;
+
+static void send_brightness_speed(struct hid_device *dev, int brightness, int speed)
 {
-	int row, col;
-	u8 color_red, color_green, color_blue;
-	
-	if (dev == NULL) {
+	int b = clamp_val(brightness, 0, BRIGHTNESS_MAX);
+	int s = clamp_val(speed, 0, SPEED_MAX);
+
+	if (b == last_sent_brightness && s == last_sent_speed)
 		return;
+
+	keyb_send_data(dev, CMD_BRIGHTNESS_SPEED, b, s, 0x00, 0x00);
+	last_sent_brightness = b;
+	last_sent_speed = s;
+}
+
+static void invalidate_brightness_speed_cache(void)
+{
+	last_sent_brightness = -1;
+	last_sent_speed = -1;
+}
+
+static void send_animation_mode(struct hid_device *dev, u8 mode_id)
+{
+	keyb_send_data(dev, CMD_ANIMATION, mode_id, 0x00, 0x00, 0x00);
+}
+
+static void send_clear(struct hid_device *dev)
+{
+	int row, col;
+
+	send_animation_mode(dev, ANIM_CLEAR);
+	for (row = 0; row < KEYBOARD_ROWS; ++row)
+		for (col = 0; col < KEYBOARD_COLUMNS; ++col)
+			keyb_send_data(dev, CMD_SET_LED,
+				       get_led_id(row, col), 0, 0, 0);
+}
+
+static void send_led_color(struct hid_device *dev, u8 led_id,
+			    u8 r, u8 g, u8 b)
+{
+	keyb_send_data(dev, CMD_SET_LED, led_id, r, g, b);
+}
+
+/* --- Effect helpers --- */
+
+static void send_random_or_custom(struct hid_device *dev, u8 cmd)
+{
+	keyb_send_data(dev, cmd, 0x00, 0x00, 0x00, 0x00);
+}
+
+static void send_custom_color(struct hid_device *dev, u8 cmd)
+{
+	keyb_send_data(dev, cmd, COLOR_CUSTOM,
+		       state.color1_r, state.color1_g, state.color1_b);
+}
+
+static bool has_custom_color(void)
+{
+	return state.color1_r || state.color1_g || state.color1_b;
+}
+
+static void send_directional_slot(struct hid_device *dev, u8 cmd,
+				   int dir, int max_dir)
+{
+	int clamped = clamp_val(dir, 0, max_dir - 1);
+	u8 slot;
+
+	if (has_custom_color()) {
+		slot = COLOR_SLOT_BASE + clamped;
+		keyb_send_data(dev, cmd, slot,
+			       state.color1_r, state.color1_g,
+			       state.color1_b);
+	} else {
+		slot = PRESET_SLOT_BASE + clamped;
+		keyb_send_data(dev, cmd, slot, 0x00, 0x00, 0x00);
+	}
+}
+
+/* --- Effect dispatch --- */
+
+static void apply_effect(struct hid_device *dev)
+{
+	if (!dev)
+		return;
+
+	switch (state.effect) {
+	case EFFECT_OFF:
+		send_clear(dev);
+		send_brightness_speed(dev, 0, state.speed);
+		return;
+
+	case EFFECT_DIRECT:
+		send_clear(dev);
+		send_brightness_speed(dev, state.brightness, state.speed);
+		return;
+
+	case EFFECT_SPECTRUM_CYCLE:
+		send_animation_mode(dev, ANIM_SPECTRUM_CYCLE);
+		break;
+
+	case EFFECT_RAINBOW_WAVE:
+		send_animation_mode(dev, ANIM_RAINBOW_WAVE);
+		break;
+
+	case EFFECT_BREATHING:
+		send_random_or_custom(dev, CMD_BREATHING);
+		break;
+
+	case EFFECT_BREATHING_COLOR:
+		send_custom_color(dev, CMD_BREATHING);
+		break;
+
+	case EFFECT_FLASHING:
+		send_random_or_custom(dev, CMD_FLASHING);
+		break;
+
+	case EFFECT_FLASHING_COLOR:
+		send_custom_color(dev, CMD_FLASHING);
+		break;
+
+	case EFFECT_RANDOM:
+		send_animation_mode(dev, ANIM_RANDOM);
+		break;
+
+	case EFFECT_RANDOM_COLOR:
+		send_animation_mode(dev, ANIM_RANDOM);
+		keyb_send_data(dev, CMD_RANDOM_COLOR, COLOR_SLOT_BASE,
+			       state.color1_r, state.color1_g, state.color1_b);
+		break;
+
+	case EFFECT_SCAN:
+		send_animation_mode(dev, ANIM_SCAN);
+		keyb_send_data(dev, CMD_SCAN_COLOR, COLOR_SLOT_BASE,
+			       state.color1_r, state.color1_g, state.color1_b);
+		keyb_send_data(dev, CMD_SCAN_COLOR, COLOR_SLOT_BASE + 1,
+			       state.color2_r, state.color2_g, state.color2_b);
+		break;
+
+	case EFFECT_SNAKE:
+		send_animation_mode(dev, ANIM_SNAKE);
+		send_directional_slot(dev, CMD_SNAKE_COLOR,
+				      state.direction, SNAKE_DIR_COUNT);
+		break;
+
+	case EFFECT_WAVE:
+		send_animation_mode(dev, ANIM_RAINBOW_WAVE);
+		send_directional_slot(dev, CMD_WAVE_COLOR,
+				      state.direction, WAVE_DIR_COUNT);
+		break;
 	}
 
-	if (mode < MODE_MAP_LENGTH) {
-		// Color modes, mode is index to mode_to_color array map
-		color_red = (mode_to_color[mode] >> 0x10) & 0xff;
-		color_green = (mode_to_color[mode] >> 0x08) & 0xff;
-		color_blue = (mode_to_color[mode] >> 0x00) & 0xff;
-		keyb_set_all(dev, color_red, color_green, color_blue);
-	} else if (mode == MODE_MAP_LENGTH) {
-		// White background, TUXEDO letters in red
-		for (row = 0; row < KEYBOARD_ROWS; ++row) {
-			for (col = 0; col < KEYBOARD_COLUMNS; ++col) {
-				if (
-					(row == 2 && col == 6) ||   // T
-					(row == 2 && col == 8) ||   // U
-					(row == 4 && col == 4) ||   // X
-					(row == 2 && col == 4) ||   // E
-					(row == 3 && col == 4) ||   // D
-					(row == 2 && col == 10)     // O
-				) {
-					clevo_mcled_cdevs[row][col].subled_info[0].intensity = 0xff;
-					clevo_mcled_cdevs[row][col].subled_info[1].intensity = 0x00;
-					clevo_mcled_cdevs[row][col].subled_info[2].intensity = 0x00;
-					keyb_send_data(dev, 0x01, get_led_id(row, col), 0xff, 0x00, 0x00);
-				} else {
-					clevo_mcled_cdevs[row][col].subled_info[0].intensity = 0xff;
-					clevo_mcled_cdevs[row][col].subled_info[1].intensity = 0xff;
-					clevo_mcled_cdevs[row][col].subled_info[2].intensity = 0xff;
-					keyb_send_data(dev, 0x01, get_led_id(row, col), 0xff, 0xff, 0xff);
-				}
-			}
+	send_brightness_speed(dev, state.brightness, state.speed);
+}
+
+/* --- sysfs attributes --- */
+
+static ssize_t effect_show(struct device *dev, struct device_attribute *attr,
+			    char *buf)
+{
+	int i, len = 0;
+
+	for (i = 0; i < EFFECT_COUNT; i++) {
+		if (i == state.effect)
+			len += sysfs_emit_at(buf, len, "[%s] ", effect_names[i]);
+		else
+			len += sysfs_emit_at(buf, len, "%s ", effect_names[i]);
+	}
+	len += sysfs_emit_at(buf, len, "\n");
+	return len;
+}
+
+static ssize_t effect_store(struct device *dev, struct device_attribute *attr,
+			     const char *buf, size_t count)
+{
+	int i;
+
+	for (i = 0; i < EFFECT_COUNT; i++) {
+		if (sysfs_streq(buf, effect_names[i])) {
+			state.effect = i;
+			apply_effect(kbdev);
+			return count;
 		}
-	} else if (mode == MODE_MAP_LENGTH + 1) {
-		// Random color animating effect, special mode
-		keyb_send_data(dev, 0x00, 0x09, 0x00, 0x00, 0x00);
+	}
+	return -EINVAL;
+}
+static DEVICE_ATTR_RW(effect);
+
+static ssize_t brightness_show(struct device *dev,
+				struct device_attribute *attr, char *buf)
+{
+	return sysfs_emit(buf, "%d\n", state.brightness);
+}
+
+static ssize_t brightness_store(struct device *dev,
+				 struct device_attribute *attr,
+				 const char *buf, size_t count)
+{
+	int val;
+
+	if (kstrtoint(buf, 10, &val))
+		return -EINVAL;
+
+	state.brightness = clamp_val(val, 0, BRIGHTNESS_MAX);
+	send_brightness_speed(kbdev, state.brightness, state.speed);
+	return count;
+}
+static DEVICE_ATTR_RW(brightness);
+
+static ssize_t speed_show(struct device *dev, struct device_attribute *attr,
+			   char *buf)
+{
+	return sysfs_emit(buf, "%d\n", state.speed);
+}
+
+static ssize_t speed_store(struct device *dev, struct device_attribute *attr,
+			    const char *buf, size_t count)
+{
+	int val;
+
+	if (kstrtoint(buf, 10, &val))
+		return -EINVAL;
+
+	state.speed = clamp_val(val, 0, SPEED_MAX);
+	send_brightness_speed(kbdev, state.brightness, state.speed);
+	return count;
+}
+static DEVICE_ATTR_RW(speed);
+
+static void get_direction_table(const char * const **names, int *count)
+{
+	if (state.effect == EFFECT_WAVE) {
+		*names = wave_direction_names;
+		*count = WAVE_DIR_COUNT;
+	} else if (state.effect == EFFECT_SNAKE) {
+		*names = snake_direction_names;
+		*count = SNAKE_DIR_COUNT;
+	} else {
+		*names = NULL;
+		*count = 0;
 	}
 }
 
-static void stop_hw(struct hid_device *dev)
+static ssize_t direction_show(struct device *dev,
+			       struct device_attribute *attr, char *buf)
 {
-	hid_hw_power(dev, PM_HINT_NORMAL);
-	kbdev = NULL;
-	hid_hw_close(dev);
-	hid_hw_stop(dev);
+	const char * const *names;
+	int dir_count, i, len = 0;
+
+	get_direction_table(&names, &dir_count);
+	if (!names)
+		return sysfs_emit(buf, "none\n");
+
+	for (i = 0; i < dir_count; i++) {
+		if (i == state.direction)
+			len += sysfs_emit_at(buf, len, "[%s] ", names[i]);
+		else
+			len += sysfs_emit_at(buf, len, "%s ", names[i]);
+	}
+	len += sysfs_emit_at(buf, len, "\n");
+	return len;
 }
 
-static int start_hw(struct hid_device *dev)
+static ssize_t direction_store(struct device *dev,
+				struct device_attribute *attr,
+				const char *buf, size_t count)
 {
-	int result;
-	result = hid_hw_start(dev, HID_CONNECT_DEFAULT);
-	if (result) {
-		pr_err("hid_hw_start failed\n");
-		goto err_stop_hw;
+	const char * const *names;
+	int dir_count, i;
+
+	get_direction_table(&names, &dir_count);
+	if (!names)
+		return -EINVAL;
+
+	for (i = 0; i < dir_count; i++) {
+		if (sysfs_streq(buf, names[i])) {
+			state.direction = i;
+			apply_effect(kbdev);
+			return count;
+		}
 	}
+	return -EINVAL;
+}
+static DEVICE_ATTR_RW(direction);
 
-	hid_hw_power(dev, PM_HINT_FULLON);
+static ssize_t show_color(char *buf, u8 r, u8 g, u8 b)
+{
+	return sysfs_emit(buf, "%02x%02x%02x\n", r, g, b);
+}
 
-	result = hid_hw_open(dev);
-	if (result) {
-		pr_err("hid_hw_open failed\n");
-		goto err_stop_hw;
-	}
+static int parse_color(const char *buf, u8 *r, u8 *g, u8 *b)
+{
+	unsigned int rgb;
 
-	kbdev = dev;
+	if (kstrtouint(buf, 16, &rgb))
+		return -EINVAL;
+
+	*r = (rgb >> 16) & 0xff;
+	*g = (rgb >> 8) & 0xff;
+	*b = rgb & 0xff;
 	return 0;
-
-err_stop_hw:
-	stop_hw(dev);
-	return result;
 }
 
-static void leds_set_brightness_mc(struct led_classdev *led_cdev, enum led_brightness brightness) {
+static ssize_t color1_show(struct device *dev, struct device_attribute *attr,
+			    char *buf)
+{
+	return show_color(buf, state.color1_r, state.color1_g, state.color1_b);
+}
+
+static ssize_t color1_store(struct device *dev, struct device_attribute *attr,
+			     const char *buf, size_t count)
+{
+	if (parse_color(buf, &state.color1_r, &state.color1_g, &state.color1_b))
+		return -EINVAL;
+
+	if (state.effect != EFFECT_DIRECT && state.effect != EFFECT_OFF)
+		apply_effect(kbdev);
+
+	return count;
+}
+static DEVICE_ATTR_RW(color1);
+
+static ssize_t color2_show(struct device *dev, struct device_attribute *attr,
+			    char *buf)
+{
+	return show_color(buf, state.color2_r, state.color2_g, state.color2_b);
+}
+
+static ssize_t color2_store(struct device *dev, struct device_attribute *attr,
+			     const char *buf, size_t count)
+{
+	if (parse_color(buf, &state.color2_r, &state.color2_g, &state.color2_b))
+		return -EINVAL;
+
+	if (state.effect == EFFECT_SCAN)
+		apply_effect(kbdev);
+
+	return count;
+}
+static DEVICE_ATTR_RW(color2);
+
+static struct attribute *ite829x_attrs[] = {
+	&dev_attr_effect.attr,
+	&dev_attr_brightness.attr,
+	&dev_attr_speed.attr,
+	&dev_attr_direction.attr,
+	&dev_attr_color1.attr,
+	&dev_attr_color2.attr,
+	NULL,
+};
+ATTRIBUTE_GROUPS(ite829x);
+
+/* --- Multicolor LED callback --- */
+
+static void leds_set_brightness_mc(struct led_classdev *led_cdev,
+				    enum led_brightness brightness)
+{
 	int i, j;
 	struct led_classdev_mc *led_cdev_mc = lcdev_to_mccdev(led_cdev);
 
-	pr_debug("leds_set_brightness_mc: channel: %d, brightness: %d, saved brightness: %d, red: %d, green: %d, blue: %d\n",
-		 led_cdev_mc->subled_info[0].channel, brightness, ti_data.brightness, led_cdev_mc->subled_info[0].intensity,
-		 led_cdev_mc->subled_info[1].intensity, led_cdev_mc->subled_info[2].intensity);
+	state.brightness = brightness;
 
-	ti_data.brightness = brightness;
-
-	for (i = 0; i < KEYBOARD_ROWS; ++i) {
-		for (j = 0; j < KEYBOARD_COLUMNS; ++j) {
+	for (i = 0; i < KEYBOARD_ROWS; ++i)
+		for (j = 0; j < KEYBOARD_COLUMNS; ++j)
 			clevo_mcled_cdevs[i][j].led_cdev.brightness = brightness;
-		}
-	}
 
-	keyb_send_data(kbdev, 0x09, brightness, 0x02, 0x00, 0x00);
+	send_brightness_speed(kbdev, state.brightness, state.speed);
 
-	keyb_send_data(kbdev, 0x01, led_cdev_mc->subled_info[0].channel,
+	send_led_color(kbdev, led_cdev_mc->subled_info[0].channel,
 		       led_cdev_mc->subled_info[0].intensity,
 		       led_cdev_mc->subled_info[1].intensity,
 		       led_cdev_mc->subled_info[2].intensity);
 }
 
+/* --- Fn key handler --- */
+
 static void key_actions(unsigned long key_code)
 {
 	mutex_lock(&input_lock);
 
-	switch (key_code) {
-	case INT_KEY_B_NEXT:
-		// Next mode
-		ti_data.mode += 1;
-
-		if (ti_data.mode >= MODE_MAP_LENGTH + MODE_EXTRAS_LENGTH) {
-			ti_data.mode = 0;
-		}
-
-		send_mode(kbdev, ti_data.mode);
-		break;
+	if (key_code == INT_KEY_B_NEXT) {
+		state.effect = (state.effect + 1) % EFFECT_COUNT;
+		apply_effect(kbdev);
 	}
 
 	mutex_unlock(&input_lock);
 }
 
-static volatile unsigned long last_key = 0;
+static volatile unsigned long last_key;
 
 static void ite_829x_key_work_handler(struct work_struct *work)
 {
@@ -249,18 +592,16 @@ static void ite_829x_key_work_handler(struct work_struct *work)
 
 static DECLARE_WORK(ite_829x_key_work, ite_829x_key_work_handler);
 
-static int keyboard_notifier_callb(struct notifier_block *nb, unsigned long code, void *_param)
+static int keyboard_notifier_callb(struct notifier_block *nb,
+				    unsigned long code, void *_param)
 {
-	struct keyboard_notifier_param *param = _param;
-	int ret = NOTIFY_OK;
+	const struct keyboard_notifier_param *param = _param;
 
-	if (!param->down) {
-		return ret;
-	}
+	if (!param->down)
+		return NOTIFY_OK;
 
-	if (mutex_is_locked(&input_lock)) {
-		return ret;
-	}
+	if (mutex_is_locked(&input_lock))
+		return NOTIFY_OK;
 
 	if (code == KBD_KEYCODE) {
 		last_key = param->value;
@@ -274,6 +615,8 @@ static struct notifier_block keyboard_notifier_block = {
 	.notifier_call = keyboard_notifier_callb
 };
 
+/* --- HID driver callbacks --- */
+
 static int probe_callb(struct hid_device *dev, const struct hid_device_id *id)
 {
 	int result, i, j;
@@ -281,49 +624,80 @@ static int probe_callb(struct hid_device *dev, const struct hid_device_id *id)
 	result = hid_parse(dev);
 	if (result) {
 		pr_err("hid_parse failed\n");
-		stop_hw(dev);
 		return result;
 	}
 
 	mutex_init(&dev_lock);
 
-	result = start_hw(dev);
-	if (result != 0) {
+	hid_buf = kzalloc(HID_DATA_SIZE, GFP_KERNEL);
+	if (!hid_buf)
+		return -ENOMEM;
+
+	result = hid_hw_start(dev, HID_CONNECT_DEFAULT);
+	if (result) {
+		pr_err("hid_hw_start failed\n");
 		return result;
 	}
 
-	keyb_send_data(kbdev, 0x09, ti_data.brightness, 0x02, 0x00, 0x00);
-	for (i = 0; i < KEYBOARD_ROWS; ++i) {
-		for (j = 0; j < KEYBOARD_COLUMNS; ++j) {
-			pr_debug("Initialize led %d to %d %d %d.\n", get_led_id(i, j), 255, 255, 255);
+	hid_hw_power(dev, PM_HINT_FULLON);
 
-			keyb_send_data(dev, 0x01, get_led_id(i, j), 255, 255, 255);
-		}
+	result = hid_hw_open(dev);
+	if (result) {
+		pr_err("hid_hw_open failed\n");
+		hid_hw_stop(dev);
+		return result;
 	}
 
+	kbdev = dev;
+
+	/* Clear all LEDs and set default brightness */
+	send_clear(dev);
+	send_brightness_speed(dev, state.brightness, state.speed);
+
+	/* Register per-key multicolor LEDs */
 	for (i = 0; i < KEYBOARD_ROWS; ++i) {
 		for (j = 0; j < KEYBOARD_COLUMNS; ++j) {
-			clevo_mcled_cdevs[i][j].led_cdev.name = "rgb:" LED_FUNCTION_KBD_BACKLIGHT;
-			clevo_mcled_cdevs[i][j].led_cdev.max_brightness = ITE829X_KBD_BRIGHTNESS_MAX;
-			clevo_mcled_cdevs[i][j].led_cdev.brightness_set = &leds_set_brightness_mc;
-			clevo_mcled_cdevs[i][j].led_cdev.brightness = ITE829X_KBD_BRIGHTNESS_DEFAULT;
+			clevo_mcled_cdevs[i][j].led_cdev.name =
+				"rgb:" LED_FUNCTION_KBD_BACKLIGHT;
+			clevo_mcled_cdevs[i][j].led_cdev.max_brightness =
+				BRIGHTNESS_MAX;
+			clevo_mcled_cdevs[i][j].led_cdev.brightness_set =
+				&leds_set_brightness_mc;
+			clevo_mcled_cdevs[i][j].led_cdev.brightness =
+				BRIGHTNESS_DEFAULT;
 			clevo_mcled_cdevs[i][j].num_colors = 3;
-			clevo_mcled_cdevs[i][j].subled_info = clevo_mcled_cdevs_subleds[i][j];
-			clevo_mcled_cdevs[i][j].subled_info[0].color_index = LED_COLOR_ID_RED;
-			clevo_mcled_cdevs[i][j].subled_info[0].intensity = 255;
-			clevo_mcled_cdevs[i][j].subled_info[0].channel = get_led_id(i, j);
-			clevo_mcled_cdevs[i][j].subled_info[1].color_index = LED_COLOR_ID_GREEN;
-			clevo_mcled_cdevs[i][j].subled_info[1].intensity = 255;
-			clevo_mcled_cdevs[i][j].subled_info[1].channel = get_led_id(i, j);
-			clevo_mcled_cdevs[i][j].subled_info[2].color_index = LED_COLOR_ID_BLUE;
-			clevo_mcled_cdevs[i][j].subled_info[2].intensity = 255;
-			clevo_mcled_cdevs[i][j].subled_info[2].channel = get_led_id(i, j);
+			clevo_mcled_cdevs[i][j].subled_info =
+				clevo_mcled_cdevs_subleds[i][j];
+			clevo_mcled_cdevs[i][j].subled_info[0].color_index =
+				LED_COLOR_ID_RED;
+			clevo_mcled_cdevs[i][j].subled_info[0].intensity = 0;
+			clevo_mcled_cdevs[i][j].subled_info[0].channel =
+				get_led_id(i, j);
+			clevo_mcled_cdevs[i][j].subled_info[1].color_index =
+				LED_COLOR_ID_GREEN;
+			clevo_mcled_cdevs[i][j].subled_info[1].intensity = 0;
+			clevo_mcled_cdevs[i][j].subled_info[1].channel =
+				get_led_id(i, j);
+			clevo_mcled_cdevs[i][j].subled_info[2].color_index =
+				LED_COLOR_ID_BLUE;
+			clevo_mcled_cdevs[i][j].subled_info[2].intensity = 0;
+			clevo_mcled_cdevs[i][j].subled_info[2].channel =
+				get_led_id(i, j);
 
-			devm_led_classdev_multicolor_register(&dev->dev, &clevo_mcled_cdevs[i][j]);
+			devm_led_classdev_multicolor_register(&dev->dev,
+				&clevo_mcled_cdevs[i][j]);
 		}
 	}
+
+	/* Create sysfs attributes for animation control */
+	result = sysfs_create_groups(&dev->dev.kobj, ite829x_groups);
+	if (result)
+		pr_warn("failed to create sysfs attributes\n");
 
 	register_keyboard_notifier(&keyboard_notifier_block);
+
+	pr_info("ITE 829x keyboard backlight initialized (%d modes, %d LEDs)\n",
+		EFFECT_COUNT, KEYBOARD_ROWS * KEYBOARD_COLUMNS);
 
 	return 0;
 }
@@ -331,38 +705,41 @@ static int probe_callb(struct hid_device *dev, const struct hid_device_id *id)
 static void remove_callb(struct hid_device *dev)
 {
 	int i, j;
+
 	unregister_keyboard_notifier(&keyboard_notifier_block);
-	for (i = 0; i < KEYBOARD_ROWS; ++i) {
-		for (j = 0; j < KEYBOARD_COLUMNS; ++j) {
-			devm_led_classdev_multicolor_unregister(&dev->dev, &clevo_mcled_cdevs[i][j]);
-		}
-	}
-	stop_hw(dev);
-	pr_debug("driver remove\n");
+	sysfs_remove_groups(&dev->dev.kobj, ite829x_groups);
+
+	for (i = 0; i < KEYBOARD_ROWS; ++i)
+		for (j = 0; j < KEYBOARD_COLUMNS; ++j)
+			devm_led_classdev_multicolor_unregister(&dev->dev,
+				&clevo_mcled_cdevs[i][j]);
+
+	hid_hw_power(dev, PM_HINT_NORMAL);
+	kbdev = NULL;
+	hid_hw_close(dev);
+	hid_hw_stop(dev);
+
+	kfree(hid_buf);
+	hid_buf = NULL;
+
+	pr_debug("driver removed\n");
 }
 
 static int driver_suspend_callb(struct device *dev)
 {
-	pr_debug("driver suspend\n");
+	pr_debug("suspend\n");
 	return 0;
 }
 
 static int driver_resume_callb(struct device *dev)
 {
-	int i, j;
-	pr_debug("driver resume\n");
-	keyb_send_data(kbdev, 0x09, ti_data.brightness, 0x02, 0x00, 0x00);
-	for (i = 0; i < KEYBOARD_ROWS; ++i) {
-		for (j = 0; j < KEYBOARD_COLUMNS; ++j) {
-			keyb_send_data(kbdev, 0x01, get_led_id(i, j),
-				       clevo_mcled_cdevs[i][j].subled_info[0].intensity,
-				       clevo_mcled_cdevs[i][j].subled_info[1].intensity,
-				       clevo_mcled_cdevs[i][j].subled_info[2].intensity);
-		}
-	}
-	send_mode(kbdev, ti_data.mode);
+	pr_debug("resume\n");
+	invalidate_brightness_speed_cache();
+	apply_effect(kbdev);
 	return 0;
 }
+
+/* --- HID driver registration --- */
 
 static const struct hid_device_id ite829x_device_table[] = {
 	{ HID_USB_DEVICE(0x048d, 0x8910) },
@@ -377,34 +754,31 @@ static struct hid_driver ite829x_driver = {
 	.id_table = ite829x_device_table,
 };
 
-static const struct dev_pm_ops ite8291_pm = {
+static const struct dev_pm_ops ite829x_pm = {
 	SET_SYSTEM_SLEEP_PM_OPS(driver_suspend_callb, driver_resume_callb)
 };
 
-static int __init ite8291_init(void)
+static int __init ite829x_init(void)
 {
 	pr_debug("module init\n");
 
-	// Known not compatible/broken device, do not even load module
 	if (dmi_match(DMI_SYS_VENDOR, "TUXEDO") &&
-	    (dmi_match(DMI_PRODUCT_SKU, "SIRIUS1601") || dmi_match(DMI_PRODUCT_SKU, "SIRIUS1602")))
+	    (dmi_match(DMI_PRODUCT_SKU, "SIRIUS1601") ||
+	     dmi_match(DMI_PRODUCT_SKU, "SIRIUS1602")))
 		return -ENODEV;
 
 	mutex_init(&input_lock);
-	
-	ite829x_driver.driver.pm = &ite8291_pm;
+
+	ite829x_driver.driver.pm = &ite829x_pm;
 
 	return hid_register_driver(&ite829x_driver);
 }
 
-static void __exit ite8291_exit(void)
+static void __exit ite829x_exit(void)
 {
 	hid_unregister_driver(&ite829x_driver);
 	pr_debug("module exit\n");
 }
 
-// ---
-// Module bootstrap
-// ---
-module_init(ite8291_init);
-module_exit(ite8291_exit);
+module_init(ite829x_init);
+module_exit(ite829x_exit);


### PR DESCRIPTION
### Summary

The current ite_829x driver only supports per-key color writes, a hardcoded speed value (0x02), and a single "Random" animation mode. This PR adds complete animation support based on the reverse-engineered ITE 8910 HID protocol.

I reverse-engineered the full protocol from the Uniwill Control Center Windows binaries (perkey_api.dll native DLL with radare2 + LedKeyboardSetting.exe .NET IL with ikdasm) and validated every command on hardware (XMG PRO E23 / Clevo PD5x, ITE 8910 firmware 1.03.02).

Full protocol documentation: https://chocapikk.com/posts/2026/reverse-engineering-ite8910-keyboard-rgb/

### What's new

13 effects controllable via sysfs:

* off, direct, spectrum_cycle, rainbow_wave
* breathing (random colors), breathing_color (custom color)
* flashing (random colors), flashing_color (custom color)
* random (random colors), random_color (custom color)
* scan (2 custom band colors)
* snake (4 diagonal directions, preset or custom color)
* wave (8 directions, preset or custom color)

New sysfs attributes under the HID device:

* `effect` - select animation mode (shows available modes with active one in brackets)
* `brightness` - 0 to 10
* `speed` - 0 to 10 (was hardcoded to 0x02)
* `direction` - wave: up/down/left/right + 4 diagonals, snake: 4 diagonals
* `color1` - hex RGB for custom color effects (e.g. ff0000)
* `color2` - hex RGB for scan second band color

### Fixes

* ClearColor (0x0C) now sends black to all 120 LEDs after clear command (firmware retains last color)
* Speed is configurable instead of hardcoded to 0x02
* Resume restores the active effect instead of just per-key colors

### Performance

* Persistent HID report buffer allocated once at probe, reused for all sends (was kzalloc/kfree per call, 121 allocations for a single clear)
* Brightness/speed change tracking to skip redundant firmware commands

### Protocol

6-byte HID feature reports with report ID 0xCC: [CC, cmd, d0, d1, d2, d3]

All commands documented in the blog post linked above and in the OpenRGB MR: https://gitlab.com/CalcProgrammer1/OpenRGB/-/merge_requests/3236

### Test plan

* [x] Hardware-tested on XMG PRO E23 (Clevo PD5x), ITE 8910 firmware 1.03.02
* [x] All 13 effects verified on hardware
* [x] Wave 8 directions verified (preset rainbow + custom color)
* [x] Snake 4 diagonal directions verified (preset + custom color)
* [x] Scan dual-color bands verified
* [x] Breathing/flashing random and custom color verified
* [x] Brightness and speed controls verified
* [x] Suspend/resume restores active effect
* [x] Module load/unload clean
* [x] cppcheck clean, zero compiler warnings (clang)
* [x] Kernel: 6.19.9-2-cachyos (x86_64)